### PR TITLE
Improve header image layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,10 +31,9 @@ nav a {
 }
 .hero-slide {
     width: 100%;
-    height: 100vh;
-    max-height: 600px;
+    height: calc(100vh - 50px);
     background-image: url('assets/portada.png');
-    background-size: cover;
+    background-size: contain;
     background-repeat: no-repeat;
     background-position: top center;
     display: flex;
@@ -42,15 +41,12 @@ nav a {
     justify-content: center;
     position: relative;
     margin-top: 50px;
-    padding-bottom: 30px;
 }
 .hero-content {
     text-align: center;
     color: white;
-    background: rgba(0, 0, 0, 0.5);
-    padding: 15px 25px;
-    border-radius: 8px;
     text-shadow: 2px 2px 6px rgba(0,0,0,0.8);
+    padding: 0 20px 40px;
 }
 .hero-content h1 {
     font-size: 2.5em;


### PR DESCRIPTION
## Summary
- adjust hero header to fill the screen and display the original image without cropping
- remove dark box behind hero text and push text to bottom of the header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d495d4860832784bb2253ef17c5f2